### PR TITLE
move ownership from maorfr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CONTAINER_ENGINE ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo docker)
 AUTH_FLAG ?= $(shell which podman >/dev/null 2>&1 && echo --authfile || echo --config)
 
-IMAGE_NAME := quay.io/maorfr/obsctl-reloader
+IMAGE_NAME := quay.io/app-sre/obsctl-reloader
 IMAGE_TAG := $(shell git rev-parse --short=7 HEAD)
 DOCKER_CONF := $(PWD)/.docker
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -73,7 +73,7 @@ objects:
             value: "${SLEEP_DURATION_SECONDS}"
 parameters:
 - name: IMAGE
-  value: quay.io/maorfr/obsctl-reloader
+  value: quay.io/app-sre/obsctl-reloader
 - name: IMAGE_TAG
   value: latest
 - name: OBSERVATORIUM_URL


### PR DESCRIPTION
as the repo was moved, it shouldn't use my own quay.io account.

moving to use `app-sre` and will setup ci + quay repo.