### PR TITLE
Add option to disable syncing logging rules

### DIFF
--- a/jsonnet/lib/obsctl-reloader.libsonnet
+++ b/jsonnet/lib/obsctl-reloader.libsonnet
@@ -9,7 +9,14 @@ local defaults = {
   image: error 'must provide image',
   imagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
-  env: error 'must provide env',
+  env: {
+    observatoriumURL: '${OBSERVATORIUM_URL}',
+    oidcAudience: '${OIDC_AUDIENCE}',
+    oidcIssuerURL: '${OIDC_ISSUER_URL}',
+    sleepDurationSeconds: '${SLEEP_DURATION_SECONDS}',
+    managedTenants: '${MANAGED_TENANTS}',
+    logRulesEnabled: 'true',
+  },
   tenantSecretMap: error 'must provide tenantSecretMap',
   resources: {},
 
@@ -122,7 +129,7 @@ function(params) {
                 '--managed-tenants=%s' % or.config.env.managedTenants,
                 '--issuer-url=%s' % or.config.env.oidcIssuerURL,
                 '--audience=%s' % or.config.env.oidcAudience,
-              ],
+              ] + if std.objectHas(or.config.env, 'logRulesEnabled') then ['--log-rules-enabled=%s' % or.config.env.logRulesEnabled ] else [],
               resources: if or.config.resources != {} then or.config.resources else {},
               env: [
                 {

--- a/jsonnet/lib/obsctl-reloader.libsonnet
+++ b/jsonnet/lib/obsctl-reloader.libsonnet
@@ -129,7 +129,7 @@ function(params) {
                 '--managed-tenants=%s' % or.config.env.managedTenants,
                 '--issuer-url=%s' % or.config.env.oidcIssuerURL,
                 '--audience=%s' % or.config.env.oidcAudience,
-              ] + if std.objectHas(or.config.env, 'logRulesEnabled') then ['--log-rules-enabled=%s' % or.config.env.logRulesEnabled ] else [],
+              ] + if std.objectHas(or.config.env, 'logRulesEnabled') then ['--log-rules-enabled=%s' % or.config.env.logRulesEnabled] else [],
               resources: if or.config.resources != {} then or.config.resources else {},
               env: [
                 {

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,7 @@ func TestSyncLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(25*time.Second, func() { cancel() })
 
-	syncLoop(ctx, log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), rl, rs, 5)
+	syncLoop(ctx, log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), rl, rs, true, 5)
 
 	testutil.Equals(t, 12, rs.setCurrentTenantCnt)
 	testutil.Equals(t, 4, rs.metricsRulesCnt)

--- a/openshift/template.jsonnet
+++ b/openshift/template.jsonnet
@@ -10,6 +10,7 @@ local or = (import '../jsonnet/lib/obsctl-reloader.libsonnet')({
     oidcIssuerURL: '${OIDC_ISSUER_URL}',
     sleepDurationSeconds: '${SLEEP_DURATION_SECONDS}',
     managedTenants: '${MANAGED_TENANTS}',
+    logRulesEnabled: true,
   },
   tenantSecretMap: [
     {

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -39,6 +39,7 @@ objects:
           - --managed-tenants=${MANAGED_TENANTS}
           - --issuer-url=${OIDC_ISSUER_URL}
           - --audience=${OIDC_AUDIENCE}
+          - --log-rules-enabled=true
           env:
           - name: NAMESPACE_NAME
             valueFrom:


### PR DESCRIPTION
This PR adds a `--log-rules-enabled` bool flag to optionally disable syncing logging rules, true by default.

This is needed in cases where Loki rule CRs are defined in an ns, but the Observatorium instance does not deploy the required logging infrastructure.