### PR TITLE
Add metrics, log level args and refactor error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,12 @@ require (
 )
 
 require (
+	github.com/efficientgo/core v1.0.0-rc.2
 	github.com/grafana/loki/operator/apis/loki v0.0.0-20230323133219-93a1c21da5c9
+	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/observatorium/api v0.1.3-0.20221005180515-c3230526775b
+	github.com/oklog/run v1.1.0
+	github.com/prometheus/client_golang v1.14.0
 	k8s.io/client-go v0.26.1
 )
 
@@ -55,7 +59,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,7 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
@@ -397,6 +398,8 @@ github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7j
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
+github.com/efficientgo/core v1.0.0-rc.2 h1:7j62qHLnrZqO3V3UA0AqOGd5d5aXV3AX6m/NZBHp78I=
+github.com/efficientgo/core v1.0.0-rc.2/go.mod h1:FfGdkzWarkuzOlY04VY+bGfb1lWrjaL6x/GLcQ4vJps=
 github.com/efficientgo/e2e v0.12.1/go.mod h1:xDHUyIqAWyVWU29Lf+BaZoavW7xAbDEvTwHWWI/3bhk=
 github.com/efficientgo/tools/core v0.0.0-20210129205121-421d0828c9a6/go.mod h1:OmVcnJopJL8d3X3sSXTiypGoUSgFq1aDGmlrdi9dn/M=
 github.com/efficientgo/tools/core v0.0.0-20210201224146-3d78f4d30648/go.mod h1:cFZoHUhKg31xkPnPjhPKFtevnx0Xcg67ptBRxbpaxtk=
@@ -1057,6 +1060,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a h1:0usWxe5SGXKQovz3p+BiQ81Jy845xSMu2CWKuXsXuUM=
 github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.6/go.mod h1:HOT/6NaBlR0f9XlxD3zolN6Z3N8Lp4pvhp+jLS5ihnI=
@@ -1150,6 +1154,7 @@ github.com/observatorium/obsctl v0.1.0-rc.0.0.20221007074049-1407ae4c8de0 h1:l5t
 github.com/observatorium/obsctl v0.1.0-rc.0.0.20221007074049-1407ae4c8de0/go.mod h1:k8Qh3P+4ZeZyzWdKJ/K0FOqxmlS7+xiu+jcY0fRGdrw=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/main.go
+++ b/main.go
@@ -5,20 +5,26 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"net/http"
 	"os"
-	"os/signal"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	lokiv1beta1 "github.com/grafana/loki/operator/apis/loki/v1beta1"
+	"github.com/metalmatze/signal/internalserver"
 	"github.com/observatorium/api/client/parameters"
 	"github.com/observatorium/obsctl/pkg/config"
 	"github.com/observatorium/obsctl/pkg/fetcher"
+	"github.com/oklog/run"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,9 +43,10 @@ const (
 type tenantRulesLoader interface {
 	getLokiAlertingRules() ([]lokiv1.AlertingRule, error)
 	getLokiRecordingRules() ([]lokiv1.RecordingRule, error)
-	getPrometheusRules() ([]*monitoringv1.PrometheusRule, error)
 	getTenantLogsAlertingRuleGroups(alertingRules []lokiv1.AlertingRule) map[string]lokiv1.AlertingRuleSpec
 	getTenantLogsRecordingRuleGroups(recordingRules []lokiv1.RecordingRule) map[string]lokiv1.RecordingRuleSpec
+
+	getPrometheusRules() ([]*monitoringv1.PrometheusRule, error)
 	getTenantMetricsRuleGroups(prometheusRules []*monitoringv1.PrometheusRule) map[string]monitoringv1.PrometheusRuleSpec
 }
 
@@ -50,51 +57,107 @@ type kubeRulesLoader struct {
 	logger         log.Logger
 	namespace      string
 	managedTenants string
+
+	promRuleFetches       prometheus.Counter
+	promRuleFetchFailures prometheus.Counter
+	lokiRuleFetches       *prometheus.CounterVec
+	lokiRuleFetchFailures *prometheus.CounterVec
+	lokiTenantRules       *prometheus.GaugeVec
+	promTenantRules       *prometheus.GaugeVec
+}
+
+func newKubeRulesLoader(
+	ctx context.Context,
+	kc client.Client,
+	logger log.Logger,
+	namespace string,
+	managedTenants string,
+	reg prometheus.Registerer,
+) *kubeRulesLoader {
+	return &kubeRulesLoader{
+		ctx:            ctx,
+		k8s:            kc,
+		logger:         logger,
+		namespace:      namespace,
+		managedTenants: managedTenants,
+
+		promRuleFetches: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rule_fetches_total",
+			Help: "Total number of list operations for monitoringv1 PrometheusRules.",
+		}),
+		promRuleFetchFailures: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rule_fetch_failures_total",
+			Help: "Total number of failed list operations for monitoringv1 PrometheusRules.",
+		}),
+		lokiRuleFetches: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_loki_rule_fetches_total",
+			Help: "Total number of list operations for lokiv1/v1beta1 rules.",
+		}, []string{"type"}),
+		lokiRuleFetchFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_loki_rule_fetch_failures_total",
+			Help: "Total number of failed list operations for lokiv1/v1beta1 rules.",
+		}, []string{"type"}),
+
+		lokiTenantRules: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "obsctl_reloader_loki_tenant_rulegroups",
+			Help: "Number of Loki rules loaded per tenant.",
+		}, []string{"type", "tenant"}),
+		promTenantRules: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "obsctl_reloader_prom_tenant_rulegroups",
+			Help: "Number of Prometheus rules loaded per tenant.",
+		}, []string{"tenant"}),
+	}
 }
 
 func (k *kubeRulesLoader) getLokiAlertingRules() ([]lokiv1.AlertingRule, error) {
 	arV1Beta1 := lokiv1beta1.AlertingRuleList{}
 	if err := k.k8s.List(k.ctx, &arV1Beta1, client.InNamespace(k.namespace)); err != nil {
-		return nil, err
+		k.lokiRuleFetchFailures.WithLabelValues("alerting").Inc()
+		return nil, errors.Wrap(err, "listing loki alerting rule v1beta1 objects")
 	}
 
 	arV1 := lokiv1.AlertingRuleList{}
 	if err := k.k8s.List(k.ctx, &arV1, client.InNamespace(k.namespace)); err != nil {
-		return nil, err
+		k.lokiRuleFetchFailures.WithLabelValues("alerting").Inc()
+		return nil, errors.Wrap(err, "listing loki alerting rule v1 objects")
 	}
 
 	for _, ar := range arV1Beta1.Items {
 		v1 := lokiv1.AlertingRule{}
 		if err := ar.ConvertTo(&v1); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "converting loki v1beta1 to v1")
 		}
 
 		arV1.Items = append(arV1.Items, v1)
 	}
 
+	k.lokiRuleFetches.WithLabelValues("alerting").Inc()
 	return arV1.Items, nil
 }
 
 func (k *kubeRulesLoader) getLokiRecordingRules() ([]lokiv1.RecordingRule, error) {
 	rrV1Beta1 := lokiv1beta1.RecordingRuleList{}
 	if err := k.k8s.List(k.ctx, &rrV1Beta1, client.InNamespace(k.namespace)); err != nil {
-		return nil, err
+		k.lokiRuleFetchFailures.WithLabelValues("recording").Inc()
+		return nil, errors.Wrap(err, "listing loki recording rule v1beta1 objects")
 	}
 
 	rrV1 := lokiv1.RecordingRuleList{}
 	if err := k.k8s.List(k.ctx, &rrV1, client.InNamespace(k.namespace)); err != nil {
-		return nil, err
+		k.lokiRuleFetchFailures.WithLabelValues("recording").Inc()
+		return nil, errors.Wrap(err, "listing loki recording rule v1 objects")
 	}
 
 	for _, ar := range rrV1Beta1.Items {
 		v1 := lokiv1.RecordingRule{}
 		if err := ar.ConvertTo(&v1); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "converting loki v1beta1 to v1")
 		}
 
 		rrV1.Items = append(rrV1.Items, v1)
 	}
 
+	k.lokiRuleFetches.WithLabelValues("recording").Inc()
 	return rrV1.Items, nil
 }
 
@@ -102,9 +165,11 @@ func (k *kubeRulesLoader) getPrometheusRules() ([]*monitoringv1.PrometheusRule, 
 	prometheusRules := monitoringv1.PrometheusRuleList{}
 	err := k.k8s.List(k.ctx, &prometheusRules, client.InNamespace(k.namespace))
 	if err != nil {
-		return nil, err
+		k.promRuleFetchFailures.Inc()
+		return nil, errors.Wrap(err, "listing prometheus rule objects")
 	}
 
+	k.promRuleFetches.Inc()
 	return prometheusRules.Items, nil
 }
 
@@ -118,18 +183,19 @@ func (k *kubeRulesLoader) getTenantLogsAlertingRuleGroups(alertingRules []lokiv1
 	}
 
 	for _, ar := range alertingRules {
-		level.Info(k.logger).Log("msg", "checking Loki alerting rule for tenant", "name", ar.Name)
+		level.Debug(k.logger).Log("msg", "checking Loki alerting rule for tenant", "name", ar.Name)
 		if _, found := tenantRules[ar.Spec.TenantID]; !found {
-			level.Info(k.logger).Log("msg", "skipping Loki alerting rule with unmanaged tenant", "name", ar.Name, "tenant", ar.Spec.TenantID)
+			level.Debug(k.logger).Log("msg", "skipping Loki alerting rule with unmanaged tenant", "name", ar.Name, "tenant", ar.Spec.TenantID)
 			continue
 		}
 
-		level.Info(k.logger).Log("msg", "checking Loki alerting rule tenant rules", "name", ar.Name, "tenant", ar.Spec.TenantID)
+		level.Debug(k.logger).Log("msg", "checking Loki alerting rule tenant rules", "name", ar.Name, "tenant", ar.Spec.TenantID)
 		tenantRules[ar.Spec.TenantID] = append(tenantRules[ar.Spec.TenantID], ar.Spec.Groups...)
 	}
 
 	tenantRuleGroups := make(map[string]lokiv1.AlertingRuleSpec, len(tenantRules))
 	for tenant, tr := range tenantRules {
+		k.lokiTenantRules.WithLabelValues("alerting", tenant).Set(float64(len(tr)))
 		tenantRuleGroups[tenant] = lokiv1.AlertingRuleSpec{Groups: tr}
 	}
 
@@ -146,18 +212,19 @@ func (k *kubeRulesLoader) getTenantLogsRecordingRuleGroups(recordingRules []loki
 	}
 
 	for _, ar := range recordingRules {
-		level.Info(k.logger).Log("msg", "checking Loki Recording rule for tenant", "name", ar.Name)
+		level.Debug(k.logger).Log("msg", "checking Loki Recording rule for tenant", "name", ar.Name)
 		if _, found := tenantRules[ar.Spec.TenantID]; !found {
-			level.Info(k.logger).Log("msg", "skipping Loki Recording rule with unmanaged tenant", "name", ar.Name, "tenant", ar.Spec.TenantID)
+			level.Debug(k.logger).Log("msg", "skipping Loki Recording rule with unmanaged tenant", "name", ar.Name, "tenant", ar.Spec.TenantID)
 			continue
 		}
 
-		level.Info(k.logger).Log("msg", "checking Loki Recording rule tenant rules", "name", ar.Name, "tenant", ar.Spec.TenantID)
+		level.Debug(k.logger).Log("msg", "checking Loki Recording rule tenant rules", "name", ar.Name, "tenant", ar.Spec.TenantID)
 		tenantRules[ar.Spec.TenantID] = append(tenantRules[ar.Spec.TenantID], ar.Spec.Groups...)
 	}
 
 	tenantRuleGroups := make(map[string]lokiv1.RecordingRuleSpec, len(tenantRules))
 	for tenant, tr := range tenantRules {
+		k.lokiTenantRules.WithLabelValues("recording", tenant).Set(float64(len(tr)))
 		tenantRuleGroups[tenant] = lokiv1.RecordingRuleSpec{Groups: tr}
 	}
 
@@ -174,21 +241,22 @@ func (k *kubeRulesLoader) getTenantMetricsRuleGroups(prometheusRules []*monitori
 	}
 
 	for _, pr := range prometheusRules {
-		level.Info(k.logger).Log("msg", "checking prometheus rule for tenant", "name", pr.Name)
+		level.Debug(k.logger).Log("msg", "checking prometheus rule for tenant", "name", pr.Name)
 		if tenant, ok := pr.Labels["tenant"]; ok {
 			if _, found := tenantRules[tenant]; !found {
-				level.Info(k.logger).Log("msg", "skipping prometheus rule with unmanaged tenant", "name", pr.Name, "tenant", tenant)
+				level.Debug(k.logger).Log("msg", "skipping prometheus rule with unmanaged tenant", "name", pr.Name, "tenant", tenant)
 				continue
 			}
-			level.Info(k.logger).Log("msg", "checking prometheus rule tenant rules", "name", pr.Name, "tenant", tenant)
+			level.Debug(k.logger).Log("msg", "checking prometheus rule tenant rules", "name", pr.Name, "tenant", tenant)
 			tenantRules[tenant] = append(tenantRules[tenant], pr.Spec.Groups...)
 		} else {
-			level.Info(k.logger).Log("msg", "skipping prometheus rule without tenant label", "name", pr.Name)
+			level.Debug(k.logger).Log("msg", "skipping prometheus rule without tenant label", "name", pr.Name)
 		}
 	}
 
 	tenantRuleGroups := make(map[string]monitoringv1.PrometheusRuleSpec, len(tenantRules))
 	for tenant, tr := range tenantRules {
+		k.promTenantRules.WithLabelValues(tenant).Set(float64(len(tr)))
 		tenantRuleGroups[tenant] = monitoringv1.PrometheusRuleSpec{Groups: tr}
 	}
 
@@ -216,6 +284,44 @@ type obsctlRulesSyncer struct {
 	managedTenants string
 
 	c *config.Config
+
+	lokiRulesSetOps      *prometheus.CounterVec
+	promRulesSetOps      *prometheus.CounterVec
+	lokiRulesSetFailures *prometheus.CounterVec
+	promRulesSetFailures *prometheus.CounterVec
+}
+
+func newObsctlRulesSyncer(
+	ctx context.Context,
+	logger log.Logger,
+	apiURL, audience, issuerURL, managedTenants string,
+	reg prometheus.Registerer,
+) *obsctlRulesSyncer {
+	return &obsctlRulesSyncer{
+		ctx:            ctx,
+		logger:         logger,
+		apiURL:         apiURL,
+		audience:       audience,
+		issuerURL:      issuerURL,
+		managedTenants: managedTenants,
+
+		lokiRulesSetOps: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_loki_rule_sets_total",
+			Help: "Total number of obsctl set operations for lokiv1/v1beta1 rules.",
+		}, []string{"type", "tenant"}),
+		promRulesSetOps: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rule_sets_total",
+			Help: "Total number of obsctl set operations for monitoringv1 rules.",
+		}, []string{"tenant"}),
+		lokiRulesSetFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_loki_rule_set_failures_total",
+			Help: "Total number of failed obsctl set operations for lokiv1/v1beta1 rules.",
+		}, []string{"type", "tenant"}),
+		promRulesSetFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rule_set_failures_total",
+			Help: "Total number of failed obsctl set operations for monitoringv1 rules.",
+		}, []string{"tenant"}),
+	}
 }
 
 // InitOrReloadObsctlConfig reads config from disk if present, or initializes one based on env vars.
@@ -223,23 +329,23 @@ func (o *obsctlRulesSyncer) initOrReloadObsctlConfig() error {
 	// Check if config is already present on disk.
 	cfg, err := config.Read(o.logger)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "reading obsctl config from disk")
 	}
 
 	if len(cfg.APIs[obsctlContextAPIName].Contexts) != 0 && cfg.APIs[obsctlContextAPIName].URL == o.apiURL {
 		o.c = cfg
-		level.Info(o.logger).Log("msg", "loading config from disk")
+		level.Info(o.logger).Log("msg", "loading obsctl config from disk")
 		return nil
 	}
 
-	level.Info(o.logger).Log("msg", "creating new config")
+	level.Info(o.logger).Log("msg", "creating new obsctl config")
 
 	// No previous config present,
 	// Add API.
 	o.c = &config.Config{}
 	if err := o.c.AddAPI(o.logger, obsctlContextAPIName, o.apiURL); err != nil {
 		level.Error(o.logger).Log("msg", "add api", "error", err)
-		return err
+		return errors.Wrap(err, "adding new API to obsctl config")
 	}
 
 	// Add all managed tenants under the API.
@@ -262,7 +368,7 @@ func (o *obsctlRulesSyncer) initOrReloadObsctlConfig() error {
 
 		if err := o.c.AddTenant(o.logger, tenantCfg.Tenant, obsctlContextAPIName, tenantCfg.Tenant, tenantCfg.OIDC); err != nil {
 			level.Error(o.logger).Log("msg", "adding tenant", "tenant", tenant, "error", err)
-			return err
+			return errors.Wrap(err, "adding tenant to obsctl config")
 		}
 	}
 
@@ -279,85 +385,94 @@ func (o *obsctlRulesSyncer) setCurrentTenant(tenant string) error {
 }
 
 func (o *obsctlRulesSyncer) obsctlLogsAlertingSet(rules lokiv1.AlertingRuleSpec) error {
-	level.Info(o.logger).Log("msg", "setting logs for tenant")
+	level.Debug(o.logger).Log("msg", "setting logs for tenant")
 	fc, currentTenant, err := fetcher.NewCustomFetcher(o.ctx, o.logger)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting fetcher client", "error", err)
-		return err
+		return errors.Wrap(err, "getting fetcher client")
 	}
 
 	for _, group := range rules.Groups {
 		body, err := yaml.Marshal(group)
 		if err != nil {
 			level.Error(o.logger).Log("msg", "converting lokiv1 alerting rule group to yaml", "error", err)
-			return err
+			o.lokiRulesSetFailures.WithLabelValues("alerting", string(currentTenant)).Inc()
+			return errors.Wrap(err, "converting lokiv1 alerting rule group to yaml")
 		}
 
-		level.Info(o.logger).Log("msg", "setting rule file", "rule", string(body))
+		level.Debug(o.logger).Log("msg", "setting rule file", "rule", string(body))
 		resp, err := fc.SetLogsRulesWithBodyWithResponse(o.ctx, currentTenant, parameters.LogRulesNamespace(currentTenant), "application/yaml", bytes.NewReader(body))
 		if err != nil {
 			level.Error(o.logger).Log("msg", "getting response", "error", err)
+			o.lokiRulesSetFailures.WithLabelValues("alerting", string(currentTenant)).Inc()
 			return err
 		}
 
 		if resp.StatusCode()/100 != 2 {
 			if len(resp.Body) != 0 {
 				level.Error(o.logger).Log("msg", "setting loki alerting rules", "error", string(resp.Body))
+				o.lokiRulesSetFailures.WithLabelValues("alerting", string(currentTenant)).Inc()
 				return err
 			}
 		}
-		level.Info(o.logger).Log("msg", string(resp.Body))
+		level.Debug(o.logger).Log("msg", string(resp.Body))
+		o.lokiRulesSetOps.WithLabelValues("alerting", string(currentTenant)).Inc()
 	}
 
 	return nil
 }
 
 func (o *obsctlRulesSyncer) obsctlLogsRecordingSet(rules lokiv1.RecordingRuleSpec) error {
-	level.Info(o.logger).Log("msg", "setting logs for tenant")
+	level.Debug(o.logger).Log("msg", "setting logs for tenant")
 	fc, currentTenant, err := fetcher.NewCustomFetcher(o.ctx, o.logger)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting fetcher client", "error", err)
-		return err
+		return errors.Wrap(err, "getting fetcher client")
 	}
 
 	for _, group := range rules.Groups {
 		body, err := yaml.Marshal(group)
 		if err != nil {
 			level.Error(o.logger).Log("msg", "converting lokiv1 recording rule group to yaml", "error", err)
-			return err
+			o.lokiRulesSetFailures.WithLabelValues("recording", string(currentTenant)).Inc()
+			return errors.Wrap(err, "converting lokiv1 recording rule group to yaml")
 		}
 
-		level.Info(o.logger).Log("msg", "setting rule file", "rule", string(body))
+		level.Debug(o.logger).Log("msg", "setting rule file", "rule", string(body))
 		resp, err := fc.SetLogsRulesWithBodyWithResponse(o.ctx, currentTenant, parameters.LogRulesNamespace(currentTenant), "application/yaml", bytes.NewReader(body))
 		if err != nil {
 			level.Error(o.logger).Log("msg", "getting response", "error", err)
+			o.lokiRulesSetFailures.WithLabelValues("recording", string(currentTenant)).Inc()
 			return err
 		}
 
 		if resp.StatusCode()/100 != 2 {
 			if len(resp.Body) != 0 {
 				level.Error(o.logger).Log("msg", "setting loki recording rules", "error", string(resp.Body))
+				o.lokiRulesSetFailures.WithLabelValues("recording", string(currentTenant)).Inc()
 				return err
 			}
 		}
-		level.Info(o.logger).Log("msg", string(resp.Body))
+		level.Debug(o.logger).Log("msg", string(resp.Body))
+		o.lokiRulesSetOps.WithLabelValues("recording", string(currentTenant)).Inc()
 	}
 
 	return nil
 }
 
 func (o *obsctlRulesSyncer) obsctlMetricsSet(rules monitoringv1.PrometheusRuleSpec) error {
-	level.Info(o.logger).Log("msg", "setting metrics for tenant")
+	level.Debug(o.logger).Log("msg", "setting metrics for tenant")
 	fc, currentTenant, err := fetcher.NewCustomFetcher(o.ctx, o.logger)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting fetcher client", "error", err)
-		return err
+		return errors.Wrap(err, "getting fetcher client")
 	}
 
 	ruleGroups, err := json.Marshal(rules)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "converting monitoringv1 rules to json", "error", err)
-		return err
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		return errors.Wrap(err, "converting monitoringv1 rules to json")
 	}
 
 	groups, errs := rulefmt.Parse(ruleGroups)
@@ -365,29 +480,35 @@ func (o *obsctlRulesSyncer) obsctlMetricsSet(rules monitoringv1.PrometheusRuleSp
 		for e := range errs {
 			level.Error(o.logger).Log("msg", "rulefmt parsing rules", "error", e, "groups", groups)
 		}
-		return errs[0]
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		return errors.Wrap(errs[0], "rulefmt parsing rules")
 	}
 
 	body, err := yaml.Marshal(groups)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "converting rulefmt rules to yaml", "error", err)
-		return err
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		return errors.Wrap(err, "converting rulefmt rules to yaml")
 	}
 
-	level.Info(o.logger).Log("msg", "setting rule file", "rule", string(body))
+	level.Debug(o.logger).Log("msg", "setting rule file", "rule", string(body))
 	resp, err := fc.SetRawRulesWithBodyWithResponse(o.ctx, currentTenant, "application/yaml", bytes.NewReader(body))
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting response", "error", err)
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
 		return err
 	}
 
 	if resp.StatusCode()/100 != 2 {
 		if len(resp.Body) != 0 {
 			level.Error(o.logger).Log("msg", "setting rules", "error", string(resp.Body))
+			o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
 			return err
 		}
 	}
-	level.Info(o.logger).Log("msg", string(resp.Body))
+
+	o.promRulesSetOps.WithLabelValues(string(currentTenant)).Inc()
+	level.Debug(o.logger).Log("msg", string(resp.Body))
 
 	return nil
 }
@@ -400,25 +521,27 @@ func syncLoop(
 	o tenantRulesSyncer,
 	logRulesEnabled bool,
 	sleepDurationSeconds uint,
-) {
+) error {
 	for {
 		select {
 		case <-time.After(time.Duration(sleepDurationSeconds) * time.Second):
 			prometheusRules, err := k.getPrometheusRules()
 			if err != nil {
 				level.Error(logger).Log("msg", "error getting prometheus rules", "error", err, "rules", len(prometheusRules))
-				os.Exit(1)
+				return err
 			}
 
 			// Set each tenant as current and set rules.
 			for tenant, ruleGroups := range k.getTenantMetricsRuleGroups(prometheusRules) {
 				if err := o.setCurrentTenant(tenant); err != nil {
 					level.Error(logger).Log("msg", "error setting tenant", "tenant", tenant, "error", err)
+					continue
 				}
 
 				err = o.obsctlMetricsSet(ruleGroups)
 				if err != nil {
 					level.Error(logger).Log("msg", "error setting rules", "tenant", tenant, "error", err)
+					continue
 				}
 			}
 
@@ -426,41 +549,45 @@ func syncLoop(
 				lokiAlertingRules, err := k.getLokiAlertingRules()
 				if err != nil {
 					level.Error(logger).Log("msg", "error getting loki alerting rules", "error", err, "rules", len(lokiAlertingRules))
-					os.Exit(1)
+					return err
 				}
 
 				for tenant, ruleGroups := range k.getTenantLogsAlertingRuleGroups(lokiAlertingRules) {
 					if err := o.setCurrentTenant(tenant); err != nil {
 						level.Error(logger).Log("msg", "error setting tenant", "tenant", tenant, "error", err)
+						continue
 					}
 
 					err = o.obsctlLogsAlertingSet(ruleGroups)
 					if err != nil {
 						level.Error(logger).Log("msg", "error setting loki alerting rules", "tenant", tenant, "error", err)
+						continue
 					}
 				}
 
 				lokiRecordingRules, err := k.getLokiRecordingRules()
 				if err != nil {
 					level.Error(logger).Log("msg", "error getting loki recording rules", "error", err, "rules", len(lokiRecordingRules))
-					os.Exit(1)
+					return err
 				}
 
 				for tenant, ruleGroups := range k.getTenantLogsRecordingRuleGroups(lokiRecordingRules) {
 					if err := o.setCurrentTenant(tenant); err != nil {
 						level.Error(logger).Log("msg", "error setting tenant", "tenant", tenant, "error", err)
+						continue
 					}
 
 					err = o.obsctlLogsRecordingSet(ruleGroups)
 					if err != nil {
 						level.Error(logger).Log("msg", "error setting loki recording rules", "tenant", tenant, "error", err)
+						continue
 					}
 				}
 			}
 
-			level.Info(logger).Log("msg", "sleeping", "duration", sleepDurationSeconds)
+			level.Debug(logger).Log("msg", "sleeping", "duration", sleepDurationSeconds)
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }
@@ -472,6 +599,30 @@ type cfg struct {
 	audience             string
 	issuerURL            string
 	logRulesEnabled      bool
+	logLevel             string
+	listenInternal       string
+}
+
+func setupLogger(logLevel string) log.Logger {
+	var lvl level.Option
+	switch logLevel {
+	case "error":
+		lvl = level.AllowError()
+	case "warn":
+		lvl = level.AllowWarn()
+	case "info":
+		lvl = level.AllowInfo()
+	case "debug":
+		lvl = level.AllowDebug()
+	default:
+		panic("unexpected log level")
+	}
+
+	logger := level.NewFilter(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), lvl)
+
+	logger = log.With(logger, "name", "obsctl-reloader")
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+	return logger
 }
 
 func parseFlags() *cfg {
@@ -485,6 +636,9 @@ func parseFlags() *cfg {
 	flag.StringVar(&cfg.audience, "audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
 	flag.BoolVar(&cfg.logRulesEnabled, "log-rules-enabled", true, "Enable syncing Loki logging rules. Always on by default.")
 
+	flag.StringVar(&cfg.logLevel, "log.level", "info", "Log filtering level. One of: debug, info, warn, error.")
+	flag.StringVar(&cfg.listenInternal, "web.internal.listen", ":8081", "The address on which the internal server listens.")
+
 	flag.Parse()
 	return cfg
 }
@@ -493,36 +647,14 @@ func main() {
 	cfg := parseFlags()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		cancel()
-	}()
 
 	namespace := os.Getenv("NAMESPACE_NAME")
 	if namespace == "" {
 		panic("Missing env var NAMESPACE_NAME")
 	}
 
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-
-	o := &obsctlRulesSyncer{
-		ctx:            ctx,
-		logger:         log.With(logger, "component", "obsctl-syncer"),
-		apiURL:         cfg.observatoriumURL,
-		audience:       cfg.audience,
-		issuerURL:      cfg.issuerURL,
-		managedTenants: cfg.managedTenants,
-	}
-
-	// Initialize config.
-	if err := o.initOrReloadObsctlConfig(); err != nil {
-		level.Error(logger).Log("msg", "error reloading/initializing obsctl config", "error", err)
-		os.Exit(1)
-	}
+	logger := setupLogger(cfg.logLevel)
+	defer level.Info(logger).Log("msg", "exiting")
 
 	// Create kubernetes client for deployments
 	k8sCfg, err := k8sconfig.GetConfig()
@@ -553,21 +685,76 @@ func main() {
 	}
 
 	opts := client.Options{Scheme: scheme.Scheme, Mapper: mapper}
-
 	k8sClient, err := client.New(k8sCfg, opts)
 	if err != nil {
 		panic("Failed to create new k8s client")
 	}
 
-	syncLoop(ctx, logger,
-		&kubeRulesLoader{
-			ctx:            ctx,
-			k8s:            k8sClient,
-			logger:         log.With(logger, "component", "kube-rules-loader"),
-			namespace:      namespace,
-			managedTenants: cfg.managedTenants,
-		}, o,
-		cfg.logRulesEnabled,
-		cfg.sleepDurationSeconds,
+	// Create prometheus registry.
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		//nolint:exhaustivestruct
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
+
+	// Initialize config.
+	o := newObsctlRulesSyncer(
+		ctx,
+		log.With(logger, "component", "obsctl-syncer"),
+		cfg.observatoriumURL,
+		cfg.audience,
+		cfg.issuerURL,
+		cfg.managedTenants,
+		reg,
+	)
+	if err := o.initOrReloadObsctlConfig(); err != nil {
+		level.Error(logger).Log("msg", "error reloading/initializing obsctl config", "error", err)
+		panic(err)
+	}
+
+	var g run.Group
+	{
+		g.Add(run.SignalHandler(ctx, os.Interrupt, syscall.SIGINT, syscall.SIGTERM))
+	}
+	{
+		g.Add(func() error {
+			level.Info(logger).Log("msg", "starting obsctl-reloader sync")
+			return syncLoop(ctx, logger,
+				newKubeRulesLoader(ctx, k8sClient, logger, namespace, cfg.managedTenants, reg),
+				o,
+				cfg.logRulesEnabled,
+				cfg.sleepDurationSeconds,
+			)
+		}, func(_ error) {
+			cancel()
+		})
+	}
+	{
+		h := internalserver.NewHandler(
+			internalserver.WithName("Internal - obsctl-reloader"),
+			internalserver.WithPrometheusRegistry(reg),
+			internalserver.WithPProf(),
+		)
+
+		//nolint:exhaustivestruct
+		s := http.Server{
+			Addr:    cfg.listenInternal,
+			Handler: h,
+		}
+
+		g.Add(func() error {
+			level.Info(logger).Log("msg", "starting internal HTTP server", "address", s.Addr)
+
+			return s.ListenAndServe() //nolint:wrapcheck
+		}, func(_ error) {
+			_ = s.Shutdown(ctx)
+			cancel()
+		})
+	}
+
+	if err := g.Run(); err != nil {
+		level.Error(logger).Log("msg", "starting run group", "error", err)
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -412,9 +412,12 @@ func (o *obsctlRulesSyncer) obsctlLogsAlertingSet(rules lokiv1.AlertingRuleSpec)
 			if len(resp.Body) != 0 {
 				level.Error(o.logger).Log("msg", "setting loki alerting rules", "error", string(resp.Body))
 				o.lokiRulesSetFailures.WithLabelValues("alerting", string(currentTenant)).Inc()
-				return err
+				return errors.Newf("non-200 status code: %v with body: %v", resp.StatusCode(), string(resp.Body))
 			}
+			o.lokiRulesSetFailures.WithLabelValues("alerting", string(currentTenant)).Inc()
+			return errors.Newf("non-200 status code: %v with empty body", resp.StatusCode())
 		}
+
 		level.Debug(o.logger).Log("msg", string(resp.Body))
 		o.lokiRulesSetOps.WithLabelValues("alerting", string(currentTenant)).Inc()
 	}
@@ -450,9 +453,12 @@ func (o *obsctlRulesSyncer) obsctlLogsRecordingSet(rules lokiv1.RecordingRuleSpe
 			if len(resp.Body) != 0 {
 				level.Error(o.logger).Log("msg", "setting loki recording rules", "error", string(resp.Body))
 				o.lokiRulesSetFailures.WithLabelValues("recording", string(currentTenant)).Inc()
-				return err
+				return errors.Newf("non-200 status code: %v with body: %v", resp.StatusCode(), string(resp.Body))
 			}
+			o.lokiRulesSetFailures.WithLabelValues("recording", string(currentTenant)).Inc()
+			return errors.Newf("non-200 status code: %v with empty body", resp.StatusCode())
 		}
+
 		level.Debug(o.logger).Log("msg", string(resp.Body))
 		o.lokiRulesSetOps.WithLabelValues("recording", string(currentTenant)).Inc()
 	}
@@ -503,8 +509,10 @@ func (o *obsctlRulesSyncer) obsctlMetricsSet(rules monitoringv1.PrometheusRuleSp
 		if len(resp.Body) != 0 {
 			level.Error(o.logger).Log("msg", "setting rules", "error", string(resp.Body))
 			o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
-			return err
+			return errors.Newf("non-200 status code: %v with body: %v", resp.StatusCode(), string(resp.Body))
 		}
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		return errors.Newf("non-200 status code: %v with empty body", resp.StatusCode())
 	}
 
 	o.promRulesSetOps.WithLabelValues(string(currentTenant)).Inc()

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,8 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/observatorium/obsctl/pkg/config"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -266,7 +268,14 @@ func TestInitOrReloadObsctlConfig(t *testing.T) {
 }
 
 func TestGetTenantMetricsRuleGroups(t *testing.T) {
-	k := &kubeRulesLoader{ctx: context.TODO(), logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))}
+	k := &kubeRulesLoader{
+		ctx:    context.TODO(),
+		logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		promTenantRules: promauto.With(prometheus.NewRegistry()).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "obsctl_reloader_prom_tenant_rulegroups",
+			Help: "Number of Prometheus rules loaded per tenant.",
+		}, []string{"tenant"}),
+	}
 
 	for _, tc := range []struct {
 		name    string
@@ -499,7 +508,14 @@ func TestGetTenantMetricsRuleGroups(t *testing.T) {
 }
 
 func TestGetTenantLokiAlertingRuleGroups(t *testing.T) {
-	k := &kubeRulesLoader{ctx: context.TODO(), logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))}
+	k := &kubeRulesLoader{
+		ctx:    context.TODO(),
+		logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		lokiTenantRules: promauto.With(prometheus.NewRegistry()).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "obsctl_reloader_loki_tenant_rulegroups",
+			Help: "Number of Loki rules loaded per tenant.",
+		}, []string{"type", "tenant"}),
+	}
 
 	for _, tc := range []struct {
 		name    string
@@ -736,7 +752,14 @@ func TestGetTenantLokiAlertingRuleGroups(t *testing.T) {
 }
 
 func TestGetTenantLokiRecordingRuleGroups(t *testing.T) {
-	k := &kubeRulesLoader{ctx: context.TODO(), logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))}
+	k := &kubeRulesLoader{
+		ctx:    context.TODO(),
+		logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		lokiTenantRules: promauto.With(prometheus.NewRegistry()).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "obsctl_reloader_loki_tenant_rulegroups",
+			Help: "Number of Loki rules loaded per tenant.",
+		}, []string{"type", "tenant"}),
+	}
 
 	for _, tc := range []struct {
 		name    string

--- a/main_test.go
+++ b/main_test.go
@@ -87,7 +87,7 @@ func TestSyncLoop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(25*time.Second, func() { cancel() })
 
-	syncLoop(ctx, log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), rl, rs, true, 5)
+	testutil.Ok(t, syncLoop(ctx, log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), rl, rs, true, 5))
 
 	testutil.Equals(t, 12, rs.setCurrentTenantCnt)
 	testutil.Equals(t, 4, rs.metricsRulesCnt)

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -34,6 +34,8 @@ objects:
       spec:
         containers:
         - args:
+          - --log.level=info
+          - --web.internal.listen=0.0.0.0:8081
           - --sleep-duration-seconds=${SLEEP_DURATION_SECONDS}
           - --observatorium-api-url=${OBSERVATORIUM_URL}
           - --managed-tenants=${MANAGED_TENANTS}
@@ -118,6 +120,25 @@ objects:
   - kind: ServiceAccount
     name: obsctl-reloader
 - apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/component: obsctl-reloader
+      app.kubernetes.io/instance: obsctl-reloader
+      app.kubernetes.io/name: obsctl-reloader
+      app.kubernetes.io/version: latest
+    name: obsctl-reloader
+    namespace: observatorium-stage
+  spec:
+    ports:
+    - name: internal
+      port: 8081
+      targetPort: 8081
+    selector:
+      app.kubernetes.io/component: obsctl-reloader
+      app.kubernetes.io/instance: obsctl-reloader
+      app.kubernetes.io/name: obsctl-reloader
+- apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
@@ -127,6 +148,20 @@ objects:
       app.kubernetes.io/version: latest
     name: obsctl-reloader
     namespace: observatorium-stage
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: obsctl-reloader
+    namespace: observatorium-stage
+  spec:
+    endpoints:
+    - port: internal
+    selector:
+      matchLabels:
+        app.kubernetes.io/component: obsctl-reloader
+        app.kubernetes.io/instance: obsctl-reloader
+        app.kubernetes.io/name: obsctl-reloader
+        app.kubernetes.io/version: latest
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/obsctl-reloader


### PR DESCRIPTION
This PR does the following,

- Add endpoint for metrics, and certain metrics to help keep track of obsctl-reloader behaviour
- Refactor error handling to allow handling tenant auth or Obs API errors instead of crashlooping
- Change log level of certain logs to debug, and add log level flag to binary
- Modify jsonnet to add new args, Service and ServiceMonitor for metrics

Will refactor code structure, and tests as a follow-up
