### PR TITLE
Improve observability on errors

### DIFF
--- a/pkg/syncer/obsctlsyncer.go
+++ b/pkg/syncer/obsctlsyncer.go
@@ -55,7 +55,7 @@ type ObsctlRulesSyncer struct {
 	promRulesSetOps      *prometheus.CounterVec
 	lokiRulesSetFailures *prometheus.CounterVec
 	promRulesSetFailures *prometheus.CounterVec
-	promDownstreamOps    *prometheus.CounterVec
+	promRulesStoreOps    *prometheus.CounterVec
 }
 
 func NewObsctlRulesSyncer(
@@ -93,8 +93,8 @@ func NewObsctlRulesSyncer(
 			Name: "obsctl_reloader_prom_rule_set_failures_total",
 			Help: "Total number of failed obsctl set operations for monitoringv1 rules.",
 		}, []string{"tenant", "reason"}),
-		promDownstreamOps: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "obsctl_reloader_prom_rule_set_downstream_ops_total",
+		promRulesStoreOps: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rules_store_ops_total",
 			Help: "Total number of downstream requests to store prometheus rules.",
 		}, []string{"tenant", "status_code"}),
 	}
@@ -357,7 +357,7 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "getting_response").Inc()
 		return err
 	}
-	o.promDownstreamOps.WithLabelValues(string(currentTenant), strconv.Itoa(resp.StatusCode())).Inc()
+	o.promRulesStoreOps.WithLabelValues(string(currentTenant), strconv.Itoa(resp.StatusCode())).Inc()
 
 	if resp.StatusCode()/100 != 2 {
 		if len(resp.Body) != 0 {

--- a/pkg/syncer/obsctlsyncer.go
+++ b/pkg/syncer/obsctlsyncer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/efficientgo/core/errors"
@@ -322,13 +323,14 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 	fc, currentTenant, err := fetcher.NewCustomFetcher(o.ctx, o.logger)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting fetcher client", "error", err)
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "get_fetcher_client").Inc()
 		return errors.Wrap(err, "getting fetcher client")
 	}
 
 	ruleGroups, err := json.Marshal(rules)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "converting monitoringv1 rules to json", "error", err)
-		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "converting_to_json").Inc()
 		return errors.Wrap(err, "converting monitoringv1 rules to json")
 	}
 
@@ -337,14 +339,14 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 		for e := range errs {
 			level.Error(o.logger).Log("msg", "rulefmt parsing rules", "error", e, "groups", groups)
 		}
-		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "parsing_rules").Inc()
 		return errors.Wrap(errs[0], "rulefmt parsing rules")
 	}
 
 	body, err := yaml.Marshal(groups)
 	if err != nil {
 		level.Error(o.logger).Log("msg", "converting rulefmt rules to yaml", "error", err)
-		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "converting_to_yaml").Inc()
 		return errors.Wrap(err, "converting rulefmt rules to yaml")
 	}
 
@@ -352,7 +354,7 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 	resp, err := fc.SetRawRulesWithBodyWithResponse(o.ctx, currentTenant, "application/yaml", bytes.NewReader(body))
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting response", "error", err)
-		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "getting_response").Inc()
 		return err
 	}
 	o.promDownstreamOps.WithLabelValues(string(currentTenant), strconv.Itoa(resp.StatusCode())).Inc()
@@ -360,10 +362,10 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 	if resp.StatusCode()/100 != 2 {
 		if len(resp.Body) != 0 {
 			level.Error(o.logger).Log("msg", "setting rules", "error", string(resp.Body))
-			o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+			o.promRulesSetFailures.WithLabelValues(string(currentTenant), "rules_store_error").Inc()
 			return errors.Newf("non-200 status code: %v with body: %v", resp.StatusCode(), string(resp.Body))
 		}
-		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
+		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "rules_store_error").Inc()
 		return errors.Newf("non-200 status code: %v with empty body", resp.StatusCode())
 	}
 

--- a/pkg/syncer/obsctlsyncer.go
+++ b/pkg/syncer/obsctlsyncer.go
@@ -54,6 +54,7 @@ type ObsctlRulesSyncer struct {
 	promRulesSetOps      *prometheus.CounterVec
 	lokiRulesSetFailures *prometheus.CounterVec
 	promRulesSetFailures *prometheus.CounterVec
+	promDownstreamOps    *prometheus.CounterVec
 }
 
 func NewObsctlRulesSyncer(
@@ -90,7 +91,11 @@ func NewObsctlRulesSyncer(
 		promRulesSetFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "obsctl_reloader_prom_rule_set_failures_total",
 			Help: "Total number of failed obsctl set operations for monitoringv1 rules.",
-		}, []string{"tenant"}),
+		}, []string{"tenant", "reason"}),
+		promDownstreamOps: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "obsctl_reloader_prom_rule_set_downstream_ops_total",
+			Help: "Total number of downstream requests to store prometheus rules.",
+		}, []string{"tenant", "status_code"}),
 	}
 }
 
@@ -350,6 +355,7 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 		o.promRulesSetFailures.WithLabelValues(string(currentTenant)).Inc()
 		return err
 	}
+	o.promDownstreamOps.WithLabelValues(string(currentTenant), strconv.Itoa(resp.StatusCode())).Inc()
 
 	if resp.StatusCode()/100 != 2 {
 		if len(resp.Body) != 0 {


### PR DESCRIPTION
This PR:

* Adds a `reason` label in `obsctl_reloader_prom_rule_set_failures_total` so that a rough reason for the failure is available in the metric.
* Created a new metric, `obsctl_reloader_prom_rules_store_ops_total`, to track the requests made to the underlying rule storage. It tracks successes and failures (with the HTTP status code of the API's response).

These two points should allow the creation of alerting rules on important problems and even route them accordingly. Examples:

* Alerts on failure to parse rules could be routed to tenants.
* Alerts on failure to store the rules could be routed to the observability platform SREs.