### PR TITLE
Increment rules set ops no matter what happens

### DIFF
--- a/pkg/syncer/obsctlsyncer.go
+++ b/pkg/syncer/obsctlsyncer.go
@@ -321,6 +321,8 @@ func (o *ObsctlRulesSyncer) LogsRecordingSet(rules lokiv1.RecordingRuleSpec) err
 func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) error {
 	level.Debug(o.logger).Log("msg", "setting metrics for tenant")
 	fc, currentTenant, err := fetcher.NewCustomFetcher(o.ctx, o.logger)
+	o.promRulesSetOps.WithLabelValues(string(currentTenant)).Inc()
+
 	if err != nil {
 		level.Error(o.logger).Log("msg", "getting fetcher client", "error", err)
 		o.promRulesSetFailures.WithLabelValues(string(currentTenant), "get_fetcher_client").Inc()
@@ -369,7 +371,6 @@ func (o *ObsctlRulesSyncer) MetricsSet(rules monitoringv1.PrometheusRuleSpec) er
 		return errors.Newf("non-200 status code: %v with empty body", resp.StatusCode())
 	}
 
-	o.promRulesSetOps.WithLabelValues(string(currentTenant)).Inc()
 	level.Debug(o.logger).Log("msg", string(resp.Body))
 
 	return nil


### PR DESCRIPTION
While working on some useful alerts for the project I stumbled upon the fact that the `obsctl_reloader_prom_rule_sets_total` metric, described as `Total number of obsctl set operations for monitoringv1 rules.` is in fact only counting the operations that succeeded. 

To facilitate the definition based on percentage of failures over total rule sets, I propose to **always** increment `obsctl_reloader_prom_rule_sets_total`, even when requests fail. 