### PR TITLE
Add initial set of suggested alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 venv/
 .docker/
 obsctl-reloader
+vendor/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,12 @@ lint: $(FAILLINT) $(GOLANGCI_LINT) $(MISSPELL) format check-git deps
 	@find . -type f | grep -v vendor/ | grep -vE '\./\..*' | xargs $(MISSPELL) -error
 
 .PHONY: manifests
-manifests: openshift/template.yaml
+manifests: template alerts
 
-openshift/template.yaml: openshift/template.jsonnet $(JSONNET) $(GOJSONTOYAML)
-	-rm -rf openshift/template.yaml
-	$(JSONNET) openshift/template.jsonnet | $(GOJSONTOYAML) > $@
+.PHONY: template
+template: $(JSONNET) $(GOJSONTOYAML)
+	$(JSONNET) openshift/template.jsonnet | $(GOJSONTOYAML) > openshift/template.yaml
+
+.PHONY: alerts
+alerts: $(JSONNET) $(GOJSONTOYAML)
+	$(JSONNET) openshift/alerts.jsonnet | $(GOJSONTOYAML) > openshift/alerts.yaml

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -38,7 +38,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Failing to set rules due to issue beforetalking to Observatorium.',
+              summary: 'Failing to set rules due to issue before talking to Observatorium.',
               description: 'obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.',
             },
           },

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -38,7 +38,7 @@
               severity: 'warning',
             },
             annotations: {
-              summary: 'Failing to set rules in the rules store.',
+              summary: 'Failing to set rules due to issue beforetalking to Observatorium.',
               description: 'obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.',
             },
           },

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -24,44 +24,6 @@
             },
           },
           {
-            alert: 'ObsCtlRulesSetFailure',
-            expr: |||
-              (
-                sum_over_time(obsctl_reloader_prom_rule_set_failures_total{%(obsctlReloaderSelector)s}[5m])
-              /
-                sum_over_time(obsctl_reloader_prom_rule_set_total{%(obsctlReloaderSelector)s}[5m])
-              ) or vector(0)
-              > 0.10
-            ||| % $._config,
-            'for': '10m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Failing to set rules in the rules store.',
-              description: 'obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} in the rules store {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.',
-            },
-          },
-          {
-            alert: 'ObsCtlRulesStoreAuthenticationError',
-            expr: |||
-              (
-                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", %(obsctlReloaderSelector)s}[5m])
-              /
-                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{%(obsctlReloaderSelector)s}[5m])
-              ) or vector(0)
-              > 0.10
-            ||| % $._config,
-            'for': '10m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              summary: 'Failing to authenticate tenant with Observatorium.',
-              description: 'Failed to authenticate tenant {{ $labels.tenant }} with Observatorium.',
-            },
-          },
-          {
             alert: 'ObsCtlFetchRulesFailed',
             expr: |||
               (

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -5,12 +5,12 @@
         name: 'obsctl-reloader.rules',
         rules: [
           {
-            alert: 'ObsCtlRulesStoreInternalServerError',
+            alert: 'ObsCtlRulesStoreServerError',
             expr: |||
               (
                 sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", %(obsctlReloaderSelector)s}[5m])
               /
-                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", %(obsctlReloaderSelector)s}[5m])
+                sum(sum_over_time(obsctl_reloader_prom_rules_store_ops_total{%(obsctlReloaderSelector)s}[5m]))
               ) or vector(0)
               > 0.10
             ||| % $._config,
@@ -48,7 +48,7 @@
               (
                 sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", %(obsctlReloaderSelector)s}[5m])
               /
-                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", %(obsctlReloaderSelector)s}[5m])
+                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{%(obsctlReloaderSelector)s}[5m])
               ) or vector(0)
               > 0.10
             ||| % $._config,

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -24,6 +24,25 @@
             },
           },
           {
+            alert: 'ObsCtlRulesSetFailure',
+            expr: |||
+              (
+                sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", %(obsctlReloaderSelector)s}[5m])
+              /
+                sum_over_time(obsctl_reloader_prom_rule_set_total{reason!="rules_store_error", %(obsctlReloaderSelector)s}[5m])
+              ) or vector(0)
+              > 0.10
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Failing to set rules in the rules store.',
+              description: 'obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.',
+            },
+          },
+          {
             alert: 'ObsCtlFetchRulesFailed',
             expr: |||
               (

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -1,0 +1,87 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'obsctl-reloader.rules',
+        rules: [
+          {
+            alert: 'ObsCtlRulesStoreInternalServerError',
+            expr: |||
+              (
+                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", %(obsctlReloaderSelector)s}[5m])
+              /
+                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", %(obsctlReloaderSelector)s}[5m])
+              ) or vector(0)
+              > 0.10
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Failing to send rules to Observatorium.',
+              description: 'Failed to send rules from tenant {{ $labels.tenant }} to store {{ $value | humanizePercentage }}% of the time with a 5xx or 4xx status code.',
+            },
+          },
+          {
+            alert: 'ObsCtlRulesSetFailure',
+            expr: |||
+              (
+                sum_over_time(obsctl_reloader_prom_rule_set_failures_total{%(obsctlReloaderSelector)s}[5m])
+              /
+                sum_over_time(obsctl_reloader_prom_rule_set_total{%(obsctlReloaderSelector)s}[5m])
+              ) or vector(0)
+              > 0.10
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Failing to set rules in the rules store.',
+              description: 'obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} in the rules store {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.',
+            },
+          },
+          {
+            alert: 'ObsCtlRulesStoreAuthenticationError',
+            expr: |||
+              (
+                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", %(obsctlReloaderSelector)s}[5m])
+              /
+                sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", %(obsctlReloaderSelector)s}[5m])
+              ) or vector(0)
+              > 0.10
+            ||| % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Failing to authenticate tenant with Observatorium.',
+              description: 'Failed to authenticate tenant {{ $labels.tenant }} with Observatorium.',
+            },
+          },
+          {
+            alert: 'ObsCtlFetchRulesFailed',
+            expr: |||
+              (
+                sum_over_time(obsctl_reloader_prom_rule_fetch_failures_total{%(obsctlReloaderSelector)s}[5m])
+              /
+                sum_over_time(obsctl_reloader_prom_rule_fetches_total{%(obsctlReloaderSelector)s}[5m])
+              ) or vector(0)
+              > 0.20
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              summary: 'Failing to fetch rules from the local cluster.',
+              description: 'obsctl-reloader is failing to fetch rules via the PrometheusRule CRD in the local cluster.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/jsonnet/lib/alerts.libsonnet
+++ b/jsonnet/lib/alerts.libsonnet
@@ -29,7 +29,7 @@
               (
                 sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", %(obsctlReloaderSelector)s}[5m])
               /
-                sum_over_time(obsctl_reloader_prom_rule_set_total{reason!="rules_store_error", %(obsctlReloaderSelector)s}[5m])
+                sum_over_time(obsctl_reloader_prom_rule_set_total{%(obsctlReloaderSelector)s}[5m])
               ) or vector(0)
               > 0.10
             ||| % $._config,

--- a/openshift/alerts.jsonnet
+++ b/openshift/alerts.jsonnet
@@ -1,0 +1,5 @@
+(import '../jsonnet/lib/alerts.libsonnet') {
+  _config+:: {
+    obsctlReloaderSelector: 'job="obsctl-reloader"',
+  }
+}.prometheusAlerts 

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -15,6 +15,20 @@ groups:
     for: 10m
     labels:
       severity: critical
+  - alert: ObsCtlRulesSetFailure
+    annotations:
+      description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
+      summary: Failing to set rules in the rules store.
+    expr: |
+      (
+        sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])
+      /
+        sum_over_time(obsctl_reloader_prom_rule_set_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])
+      ) or vector(0)
+      > 0.10
+    for: 10m
+    labels:
+      severity: warning
   - alert: ObsCtlFetchRulesFailed
     annotations:
       description: obsctl-reloader is failing to fetch rules via the PrometheusRule CRD in the local cluster.

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -18,7 +18,7 @@ groups:
   - alert: ObsCtlRulesSetFailure
     annotations:
       description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
-      summary: Failing to set rules due to issue beforetalking to Observatorium.
+before talking
     expr: |
       (
         sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -1,7 +1,7 @@
 groups:
 - name: obsctl-reloader.rules
   rules:
-  - alert: ObsCtlRulesStoreInternalServerError
+  - alert: ObsCtlRulesStoreServerError
     annotations:
       description: Failed to send rules from tenant {{ $labels.tenant }} to store {{ $value | humanizePercentage }}% of the time with a 5xx or 4xx status code.
       summary: Failing to send rules to Observatorium.

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -18,7 +18,7 @@ groups:
   - alert: ObsCtlRulesSetFailure
     annotations:
       description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
-      summary: Failing to set rules in the rules store.
+      summary: Failing to set rules due to issue beforetalking to Observatorium.
     expr: |
       (
         sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -23,7 +23,7 @@ groups:
       (
         sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])
       /
-        sum_over_time(obsctl_reloader_prom_rule_set_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])
+        sum_over_time(obsctl_reloader_prom_rule_set_total{job="obsctl-reloader"}[5m])
       ) or vector(0)
       > 0.10
     for: 10m

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -9,7 +9,7 @@ groups:
       (
         sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", job="obsctl-reloader"}[5m])
       /
-        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", job="obsctl-reloader"}[5m])
+        sum(sum_over_time(obsctl_reloader_prom_rules_store_ops_total{job="obsctl-reloader"}[5m]))
       ) or vector(0)
       > 0.10
     for: 10m
@@ -37,7 +37,7 @@ groups:
       (
         sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", job="obsctl-reloader"}[5m])
       /
-        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", job="obsctl-reloader"}[5m])
+        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{job="obsctl-reloader"}[5m])
       ) or vector(0)
       > 0.10
     for: 10m

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -18,7 +18,7 @@ groups:
   - alert: ObsCtlRulesSetFailure
     annotations:
       description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} before reaching Observatorium {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
-before talking
+      summary: Failing to set rules due to issue before talking to Observatorium.
     expr: |
       (
         sum_over_time(obsctl_reloader_prom_rule_set_failures_total{reason!="rules_store_error", job="obsctl-reloader"}[5m])

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -1,0 +1,59 @@
+groups:
+- name: obsctl-reloader.rules
+  rules:
+  - alert: ObsCtlRulesStoreInternalServerError
+    annotations:
+      description: Failed to send rules from tenant {{ $labels.tenant }} to store {{ $value | humanizePercentage }}% of the time with a 5xx or 4xx status code.
+      summary: Failing to send rules to Observatorium.
+    expr: |
+      (
+        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"5..|4..", job="obsctl-reloader"}[5m])
+      /
+        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", job="obsctl-reloader"}[5m])
+      ) or vector(0)
+      > 0.10
+    for: 10m
+    labels:
+      severity: critical
+  - alert: ObsCtlRulesSetFailure
+    annotations:
+      description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} in the rules store {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
+      summary: Failing to set rules in the rules store.
+    expr: |
+      (
+        sum_over_time(obsctl_reloader_prom_rule_set_failures_total{job="obsctl-reloader"}[5m])
+      /
+        sum_over_time(obsctl_reloader_prom_rule_set_total{job="obsctl-reloader"}[5m])
+      ) or vector(0)
+      > 0.10
+    for: 10m
+    labels:
+      severity: warning
+  - alert: ObsCtlRulesStoreAuthenticationError
+    annotations:
+      description: Failed to authenticate tenant {{ $labels.tenant }} with Observatorium.
+      summary: Failing to authenticate tenant with Observatorium.
+    expr: |
+      (
+        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", job="obsctl-reloader"}[5m])
+      /
+        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"2..", job="obsctl-reloader"}[5m])
+      ) or vector(0)
+      > 0.10
+    for: 10m
+    labels:
+      severity: warning
+  - alert: ObsCtlFetchRulesFailed
+    annotations:
+      description: obsctl-reloader is failing to fetch rules via the PrometheusRule CRD in the local cluster.
+      summary: Failing to fetch rules from the local cluster.
+    expr: |
+      (
+        sum_over_time(obsctl_reloader_prom_rule_fetch_failures_total{job="obsctl-reloader"}[5m])
+      /
+        sum_over_time(obsctl_reloader_prom_rule_fetches_total{job="obsctl-reloader"}[5m])
+      ) or vector(0)
+      > 0.20
+    for: 5m
+    labels:
+      severity: critical

--- a/openshift/alerts.yaml
+++ b/openshift/alerts.yaml
@@ -15,34 +15,6 @@ groups:
     for: 10m
     labels:
       severity: critical
-  - alert: ObsCtlRulesSetFailure
-    annotations:
-      description: obsctl-reloader is failing to set rules for tenant {{ $labels.tenant }} in the rules store {{ $value | humanizePercentage }}% of the time due to {{ $labels.reason }}.
-      summary: Failing to set rules in the rules store.
-    expr: |
-      (
-        sum_over_time(obsctl_reloader_prom_rule_set_failures_total{job="obsctl-reloader"}[5m])
-      /
-        sum_over_time(obsctl_reloader_prom_rule_set_total{job="obsctl-reloader"}[5m])
-      ) or vector(0)
-      > 0.10
-    for: 10m
-    labels:
-      severity: warning
-  - alert: ObsCtlRulesStoreAuthenticationError
-    annotations:
-      description: Failed to authenticate tenant {{ $labels.tenant }} with Observatorium.
-      summary: Failing to authenticate tenant with Observatorium.
-    expr: |
-      (
-        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{status_code=~"403", job="obsctl-reloader"}[5m])
-      /
-        sum_over_time(obsctl_reloader_prom_rules_store_ops_total{job="obsctl-reloader"}[5m])
-      ) or vector(0)
-      > 0.10
-    for: 10m
-    labels:
-      severity: warning
   - alert: ObsCtlFetchRulesFailed
     annotations:
       description: obsctl-reloader is failing to fetch rules via the PrometheusRule CRD in the local cluster.


### PR DESCRIPTION
* Alerts that might fire because of how tenants define their rules or Observatorium credentials are all set to `severity: "warning"`. 
* Alerts that might fire because of problems in `obsctl-reloader` itself are set to `severity: "critical"`. Examples: listing the `PrometheusRule` CRDs in the cluster and communicating with Observatorium's rules API.

Looking for a good review of the summary and descriptions, particularly for the string templating there.