### PR TITLE
RHOBS-1340: Add Jenkinsfile for GitHub Branch Source plugin migration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,49 @@
+pipeline {
+    agent {
+        node {
+            label 'rhel8-spot'
+        }
+    }
+
+    options {
+        timestamps()
+    }
+
+    stages {
+        stage('PR Check') {
+            when {
+                changeRequest()
+            }
+            steps {
+                sh './pr_check.sh'
+            }
+        }
+
+        stage('Build') {
+            when {
+                branch 'main'
+            }
+            steps {
+                wrap([$class: 'VaultBuildWrapper',
+                    vaultSecrets: [
+                        [
+                            path: 'app-sre/quay/app-sre-push',
+                            secretValues: [
+                                [envVar: 'QUAY_USER', vaultKey: 'user'],
+                                [envVar: 'QUAY_TOKEN', vaultKey: 'token']
+                            ]
+                        ]
+                    ]
+                ]) {
+                    sh './build_deploy.sh'
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
Migrate from GHPRB-based freestyle jobs to a multibranch pipeline using the GitHub Branch Source plugin. The Jenkinsfile defines PR check and build stages, delegating to the existing pr_check.sh and build_deploy.sh scripts.